### PR TITLE
Mention RACK_ENV in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Create config file (see [Configuration](#configuration) section in README).
 Start the Ginatra server:
 
 ```sh
-ginatra run
+RACK_ENV=production ginatra run
 ```
 
 By default Ginatra will run on `localhost:9797`
@@ -60,6 +60,7 @@ Create config file or modify existing (see [Configuration](#configuration) secti
 Start the Ginatra server:
 
 ```sh
+export RACK_ENV=production 
 ./bin/ginatra run
 ```
 


### PR DESCRIPTION
In order to run ginatra w/o development dependencies you have to export `RACK_ENV=production` before starting ginatra.

Closes #29