### PR TITLE
Add Docker support (Dockerfile).

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+FROM ruby:2.2
+
+ENV GINATRA_PORT 9797
+
+RUN apt-get update \
+  && apt-get install -y git cmake \
+  && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /usr/src/app
+COPY . /usr/src/app
+RUN bundle install \
+	&& apt-get purge -y --auto-remove cmake
+
+EXPOSE 9797
+CMD bundle exec puma --port $GINATRA_PORT ./config.ru

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,5 @@
 source 'https://rubygems.org'
 
 gemspec
+
+gem 'puma'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -22,6 +22,8 @@ GEM
     erubis (2.7.0)
     hike (1.2.3)
     multi_json (1.10.1)
+    puma (2.10.2)
+      rack (>= 1.1, < 2.0)
     rack (1.6.0)
     rack-protection (1.5.3)
       rack
@@ -67,6 +69,7 @@ DEPENDENCIES
   better_errors (~> 1.1.0)
   binding_of_caller
   ginatra!
+  puma
   rack-test
   rake
   rspec


### PR DESCRIPTION
I'd like to be able to run Ginatra via Docker and instead of just creating my own I figured it would be good to have an 'official' Ginatra image on the [Docker Hub Registry](https://registry.hub.docker.com/).

Docker needs the app to run in the foreground and I also wanted to be able to set the port the app runs on by passing Docker an environment variable.  This is the reasoning behind adding Puma in order to serve the app rather than using the built-in `bin/ginatra run`.  I added it directly to the Gemfile as I didn't want to mess with your gemspec and it technically isn't a dependency.  I'm sure there is a better way to achieve the same result.

The image it creates seems excessively large at 911MB however the official [Ruby image](https://registry.hub.docker.com/_/ruby/) that it is based upon is 830MB so I think this is a problem with that image and should be addressed there.

If you are unfamiliar with Docker you can build the image like so:

```
docker build -t ginatra/ginatra .
```

Docker Hub will automate and do the builds for you once setup.

In order to run the built image with a custom `config.yml` you can do:

```
docker run --name ginatra \
  -p 9797:9797 \
  -v /some/config.yml:/root/.ginatra/config.yml:ro \
  -v /path/to/repos:/repos:ro \
  ginatra/ginatra
```

You could also pass that command `-e GINATRA_PORT=8080` if you wanted to set a different port for Ginatra to run on.
