### PR TITLE
Handle missing description file in repo

### DIFF
--- a/lib/ginatra/repo.rb
+++ b/lib/ginatra/repo.rb
@@ -14,7 +14,7 @@ module Ginatra
       @param = File.split(path).last
       @name = @param
       @description = ''
-      if File.exists?("#{@repo.path}description") then
+      if File.exists?("#{@repo.path}description")
         @description = File.read("#{@repo.path}description").strip
         @description = '' if @description.match(/\AUnnamed repository;/)
       end

--- a/lib/ginatra/repo.rb
+++ b/lib/ginatra/repo.rb
@@ -13,8 +13,11 @@ module Ginatra
       @repo = Rugged::Repository.new(path)
       @param = File.split(path).last
       @name = @param
-      @description = File.read("#{@repo.path}description").strip
-      @description = '' if @description.match(/\AUnnamed repository;/)
+      @description = ''
+      if File.exists?("#{@repo.path}description") then
+        @description = File.read("#{@repo.path}description").strip
+        @description = '' if @description.match(/\AUnnamed repository;/)
+      end
     end
 
     # Return a commit corresponding to sha in the repo.


### PR DESCRIPTION
Fix to stop ginatra erroring if one of the repos in git_dirs does not have a .git/description file.
As discussed on issue #33 