### PR TITLE
Better handling for user config errors

### DIFF
--- a/bin/ginatra
+++ b/bin/ginatra
@@ -4,7 +4,7 @@ $:.unshift File.expand_path('../../lib', __FILE__)
 
 ENV['RACK_ENV'] ||= 'production'
 
-require 'ginatra'
+require 'ginatra/config'
 require 'optparse'
 
 options = {

--- a/config.yml
+++ b/config.yml
@@ -1,5 +1,6 @@
 # Default config file for Ginatra
 # Settings specified in '~/.ginatra/config.yml' will take precedence over these
+# Include ./repos/* in your config.yml if you are running rspecs 
 git_dirs:
   - ./repos/*
 description: "My Git Repositories"

--- a/config.yml
+++ b/config.yml
@@ -1,6 +1,5 @@
 # Default config file for Ginatra
 # Settings specified in '~/.ginatra/config.yml' will take precedence over these
-# Include ./repos/* in your config.yml if you are running rspecs 
 git_dirs:
   - ./repos/*
 description: "My Git Repositories"

--- a/lib/ginatra/config.rb
+++ b/lib/ginatra/config.rb
@@ -15,13 +15,23 @@ module Ginatra
     custom_config_file  = File.expand_path("~/.ginatra/config.yml")
     default_config_file = File.expand_path("#{current_path}/../../config.yml")
 
-    config = YAML.load_file(default_config_file)
+    # Our own file should be there and we don't need to check its syntax
+    abort 'ginatra config file #{default_config_file} is missing.' unless File.exists?(default_config_file)
+    final_config = YAML.load_file(default_config_file)
 
-    if File.exist?(custom_config_file)
-      custom_config = YAML.load_file(custom_config_file)
-      config.merge!(custom_config)
+    # User config file may not exist or be broken
+    if File.exists?(custom_config_file)
+      begin
+        custom_config = YAML.load_file(custom_config_file)
+      rescue Psych::SyntaxError => ex
+        puts "Cannot parse your config file #{ex.message}."
+        custom_config = {}
+      end
+      final_config.merge!(custom_config)
+    else
+      puts "User config file #{custom_config_file} absent. Will only see repos in #{final_config["git_dirs"].join(", ")}."
     end
 
-    config
+    final_config
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -16,3 +16,5 @@ RSpec.configure do |config|
   config.include Rack::Test::Methods
   config.include Ginatra::Helpers
 end
+
+Ginatra.config.git_dirs << "./repos/*" unless Ginatra.config.git_dirs.include?('./repos/*')


### PR DESCRIPTION
- Avoid loading entire app twice (once to read port and host options for rackup and again when rackup actually runs) by only requiring ginatra/config in bin/ginatra
- Warning comment in default config.yml about rspecs needing git_dirs ./repo/* for first timers
- Warn if user config file missing or broken