### PR TITLE
Re-read the config files when get /

### DIFF
--- a/lib/ginatra/repo_list.rb
+++ b/lib/ginatra/repo_list.rb
@@ -29,7 +29,7 @@ module Ginatra
     def refresh
       list.clear
 
-      Ginatra.config.git_dirs.map do |git_dir|
+      Ginatra.load_config["git_dirs"].map do |git_dir|
         if Dir.exist?(git_dir.chop)
           dirs = Dir.glob(git_dir).sort
         else


### PR DESCRIPTION
Stopping and re-starting the server just to re-read the config file is awkward. This change causes the config files to be re-read when / is visited. For example just add a new line to git_dirs in ~/.ginatra/config.yml and see it immediately at localhost:9797.

Obviously changing params for rackup such as port and localhost won't show any effect without a restart.